### PR TITLE
Conflicts with cloudfoundry-cli from pivotal/tap

### DIFF
--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -9,6 +9,8 @@ class CfCli < Formula
 
   depends_on :arch => :x86_64
 
+  conflicts_with "cloudfoundry-cli", :because => "the Pivotal tap ships an older cli distribution"
+
   def install
     bin.install 'cf'
   end


### PR DESCRIPTION
Explicitly call out conflict with the versions from the pivotal tap. This relies on the name change from [`cloudfoundry-cli`][1] to `cf-cli`.

[1]: https://github.com/pivotal/homebrew-tap/blob/e29dd37a3af035883a77a3d40048c6c9690f4871/cloudfoundry-cli.rb