### PR TITLE
Cloud Foundry CLI Formula Rename

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,3 @@
+{
+  "cloudfoundry-cli": "cf-cli"
+}


### PR DESCRIPTION
This change adds a Homebrew artifact to enable the Pivotal Homebrew tap to transfer the Cloud Foundry CLI artifact to this repository.  This file is needed since the original name of the formula was not used in this repository.