### PR TITLE
CF CLI SHA256

### DIFF
--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -5,7 +5,7 @@ class CfCli < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.16.1&source=homebrew'
   version '6.16.1'
-  sha1 '940a5500557e77be08cc1f9f9040b0775be21551'
+  sha256 'ba58dda9d4732369ac026524384c9c4d2cabe118f82889b91e2b8a2fc5faa302'
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
Recent versions of Homebrew have started printing warnings that SHA1 hashes are deprecated and will soon be removed in lieu of SHA256 hashes.  This change updates the CF CLI formula to use a SHA256 hash.