### PR TITLE
Upgrade bosh-init to 0.0.99

### DIFF
--- a/bosh-init.rb
+++ b/bosh-init.rb
@@ -1,9 +1,9 @@
 class BoshInit < Formula
   desc "creates and updates the Director VM"
   homepage "https://github.com/cloudfoundry/bosh-init"
-  version "0.0.98"
+  version "0.0.99"
   url "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-#{version}-darwin-amd64"
-  sha256 "05f3b10c9adb78d45c367b902bec37e8379c5a044d45fde55d0a42b916a8eb40"
+  sha256 "3a2f63493ecede7b9d99d46ffd0c99d5c40edd44db6ddd97ffcc52c56b4ebb89"
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
Might want to double check that I did the SHA256 calculation correctly:

```
$ sha256sum /Users/tsaleh/Downloads/bosh-init-0.0.99-darwin-amd64
3a2f63493ecede7b9d99d46ffd0c99d5c40edd44db6ddd97ffcc52c56b4ebb89  /Users/tsaleh/Downloads/bosh-init-0.0.99-darwin-amd64
```