### PR TITLE
Update formulas to work with linux machines

### DIFF
--- a/bbl.rb
+++ b/bbl.rb
@@ -1,13 +1,13 @@
 class Bbl < Formula
   desc "Command line utility for standing up a BOSH director on an IAAS of your choice."
-  homepage "https://github.com/cloudfoundry/bosh-bootloader"
-  version "v4.10.3"
+  homepage 'https://github.com/cloudfoundry/bosh-bootloader'
+  version 'v4.10.3'
   if OS.mac?
     url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_osx"
-    sha256 ""
+    sha256 'd26d512738d09d1e42b1faa04cda40d9773e5f08b23b6c78f493d94931d0cd6f'
   elsif OS.linux?
     url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_linux_x86-64"
-    sha256 ""
+    sha256 'd3de414360810c9d616fbe1127dd3590a2e0c7a81df5571f59a66cc04b12441f'
   end
 
   depends_on :arch => :x86_64

--- a/bbl.rb
+++ b/bbl.rb
@@ -2,8 +2,13 @@ class Bbl < Formula
   desc "Command line utility for standing up a BOSH director on an IAAS of your choice."
   homepage "https://github.com/cloudfoundry/bosh-bootloader"
   version "v4.10.3"
-  url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_osx"
-  sha256 ""
+  if OS.mac?
+    url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_osx"
+    sha256 ""
+  elsif OS.linux?
+    url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_linux_x86-64"
+    sha256 ""
+  end
 
   depends_on :arch => :x86_64
   depends_on "terraform" => "0.10.0"
@@ -11,7 +16,11 @@ class Bbl < Formula
 
   def install
     binary_name = "bbl"
-    bin.install "bbl-#{version}_osx" => binary_name
+    if OS.mac?
+        bin.install "bbl-#{version}_osx" => binary_name
+    elsif OS.linux?
+        bin.install "bbl-#{version}_linux_x86-64" => binary_name
+    end
   end
 
   test do

--- a/bosh-cli.rb
+++ b/bosh-cli.rb
@@ -2,8 +2,13 @@ class BoshCli < Formula
   desc "New BOSH CLI (beta)"
   homepage "https://bosh.io/docs/cli-v2.html"
   version "2.0.41"
-  url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-amd64"
-  sha256 "609d1deb762d63cf68aef5cd1ea9ddc676ddc2add72892539e123015f5b54232"
+  if OS.mac?
+    url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-amd64"
+    sha256 "609d1deb762d63cf68aef5cd1ea9ddc676ddc2add72892539e123015f5b54232"
+  elsif OS.linux?
+    url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-linux-amd64"
+    sha256 "a9d1278ae1e38b0b54dc2b1f3cb08b4d3af4021d9b934f97265208f86ef6fd92"
+  end
 
   depends_on :arch => :x86_64
 
@@ -11,7 +16,11 @@ class BoshCli < Formula
 
   def install
     binary_name = build.with?("bosh2") ? "bosh2" : "bosh"
-    bin.install "bosh-cli-#{version}-darwin-amd64" => binary_name
+    if OS.mac?
+      bin.install "bosh-cli-#{version}-darwin-amd64" => binary_name
+    elsif OS.linux?
+      bin.install "bosh-cli-#{version}-linux-amd64" => binary_name
+    end
   end
 
   test do

--- a/bosh-init.rb
+++ b/bosh-init.rb
@@ -2,15 +2,24 @@ class BoshInit < Formula
   desc "creates and updates the Director VM"
   homepage "https://github.com/cloudfoundry/bosh-init"
   version "0.0.99"
-  url "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-#{version}-darwin-amd64"
-  sha256 "3a2f63493ecede7b9d99d46ffd0c99d5c40edd44db6ddd97ffcc52c56b4ebb89"
+  if OS.mac?
+    url "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-#{version}-darwin-amd64"
+    sha256 "3a2f63493ecede7b9d99d46ffd0c99d5c40edd44db6ddd97ffcc52c56b4ebb89"
+  elsif OS.linux?
+    url "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-#{version}-linux-amd64"
+    sha256 "e72831813e1c020e5087d6c05a11dd638e628ad9315442d7d235db4d59d6e5ea"
+  end
 
   depends_on :arch => :x86_64
 
   conflicts_with "pivotal/tap/bosh-init", :because => "the Pivotal tap ships an older bosh-init version and is outdated"
 
   def install
-    bin.install "bosh-init-#{version}-darwin-amd64" => "bosh-init"
+    if OS.mac?
+      bin.install "bosh-init-#{version}-darwin-amd64" => "bosh-init"
+    elsif OS.linux?
+      bin.install "bosh-init-#{version}-linux-amd64" => "bosh-init"
+    end
   end
 
   test do

--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -5,10 +5,10 @@ class CfCli < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   version '6.32.0'
   if OS.mac?
-    url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
+    url "https://cli.run.pivotal.io/stable?release=macosx64-binary&version=#{version}&source=homebrew"
     sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
   elsif OS.linux?
-    url 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0&source=homebrew'
+    url "https://cli.run.pivotal.io/stable?release=linux64-binary&version=#{version}&source=homebrew"
     sha256 '0a05521b7198dc8b92efbfb02a8fb04c84eeffeded3387aa3c9eb92ce4abef69'
   end
 

--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -3,9 +3,14 @@ require 'formula'
 class CfCli < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
   version '6.32.0'
-  sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
+  if OS.mac?
+    url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
+    sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
+  elsif OS.linux?
+    url 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0&source=homebrew'
+    sha256 '0a05521b7198dc8b92efbfb02a8fb04c84eeffeded3387aa3c9eb92ce4abef69'
+  end
 
   depends_on :arch => :x86_64
 

--- a/credhub-cli.rb
+++ b/credhub-cli.rb
@@ -3,10 +3,10 @@ class CredhubCli < Formula
   homepage "https://github.com/cloudfoundry-incubator/credhub-cli"
   version "1.4.1"
   if OS.mac?
-    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.4.1/credhub-darwin-1.4.1.tgz"
+    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/#{version}/credhub-darwin-#{version}.tgz"
     sha256 "7da92f5fec350ff42d1d111a7cfc3d4c254cc086add48a470b6ed255c262b963"
   elsif OS.linux?
-    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.4.1/credhub-linux-1.4.1.tgz"
+    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/#{version}/credhub-linux-#{version}.tgz"
     sha256 "a9a70389919f3e16e4e0e925d59eb831ba18666a4272f209f6a740fc7a4d6a50"
   end
 

--- a/credhub-cli.rb
+++ b/credhub-cli.rb
@@ -2,8 +2,13 @@ class CredhubCli < Formula
   desc "CredHub CLI"
   homepage "https://github.com/cloudfoundry-incubator/credhub-cli"
   version "1.4.1"
-  url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.4.1/credhub-darwin-1.4.1.tgz"
-  sha256 "7da92f5fec350ff42d1d111a7cfc3d4c254cc086add48a470b6ed255c262b963"
+  if OS.mac?
+    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.4.1/credhub-darwin-1.4.1.tgz"
+    sha256 "7da92f5fec350ff42d1d111a7cfc3d4c254cc086add48a470b6ed255c262b963"
+  elsif OS.linux?
+    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.4.1/credhub-linux-1.4.1.tgz"
+    sha256 "a9a70389919f3e16e4e0e925d59eb831ba18666a4272f209f6a740fc7a4d6a50"
+  end
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
People using linuxbrew (linux version of homebrew, http://linuxbrew.sh/) that are using this tap will get the mac os binaries, which will not work. I've updated the formulas to make them work with linux as well.

I see some automatic commits on this repos, so I'm a little afraid that these will get reverted on the next automatic commit. Who should I talk to about that ?