### PR TITLE
Remove `conflicts_with` sections from cf-cli

### DIFF
--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -16,9 +16,6 @@ class CfCli < Formula
 
   depends_on :arch => :x86_64
 
-  conflicts_with "pivotal/tap/cloudfoundry-cli", :because => "the Pivotal tap ships an older cli distribution"
-  conflicts_with "caskroom/cask/cloudfoundry-cli", :because => "the caskroom tap is not the official distribution"
-
   def install
     bin.install 'cf'
     (bash_completion/"cf-cli").write <<-completion


### PR DESCRIPTION
The other taps no longer contain `cloudfoundry-cli` formulae, so these warnings are outdated.