### PR TITLE
Stop warning of a conflict with other cloud foundry CLIs

### DIFF
--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -16,9 +16,6 @@ class CfCli < Formula
 
   depends_on :arch => :x86_64
 
-  conflicts_with "pivotal/tap/cloudfoundry-cli", :because => "the Pivotal tap ships an older cli distribution"
-  conflicts_with "caskroom/cask/cloudfoundry-cli", :because => "the caskroom tap is not the official distribution"
-
   def install
     bin.install 'cf'
     (bash_completion/"cf-cli").write <<-completion


### PR DESCRIPTION
I believe (correct me if I'm wrong) that each of these alternatives have
been removed for a while now and are not just deprecated, they're not in
active circulation