### PR TITLE
support credhub CLI 2.0 by installing it as credhub2

### DIFF
--- a/credhub2-cli.rb
+++ b/credhub2-cli.rb
@@ -1,0 +1,20 @@
+class Credhub2Cli < Formula
+  desc 'CredHub 2.0 CLI'
+  homepage 'https://github.com/cloudfoundry-incubator/credhub-cli'
+  version '2.0.0'
+  url 'https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.0.0/credhub-darwin-2.0.0.tgz'
+  sha256 '2951e134775dd240ca488488fb8f4059b340f9cf0ee4a5555225371ff46a9f8f'
+
+  depends_on arch: :x86_64
+
+  option 'without-credhub2', "Don't rename binary to 'credhub2'. Useful if only working against v2.0 of credhub"
+
+  def install
+    binary_name = build.without?('credhub2') ? 'credhub' : 'credhub2'
+    bin.install 'credhub' => binary_name
+  end
+
+  test do
+    system "#{bin}/#{binary_name} --help"
+  end
+end


### PR DESCRIPTION
This introduces the credhub v2.0.0 CLI is the `credhub2` binary. This allows the two CLIs to coexist without affecting each other.

The pattern for the suffix `2` was set by `bosh` CLI when they were migrating to v2. This separation allowed older scripts to still run without having to be updated, especially with CI systems.

If the user knows they are only using 2.0 and does not prefer the suffix of `2`, the `--without-credhub2` option can be specified when installing.

For `credhub2` use `brew install cloudfoundry/tap/credhub2-cli`.
For `credhub` user `brew install cloudfoundry/tap/credhub2-cli --without-credhub2`.