### PR TITLE
bosh-init: Fix style issues found by `brew audit --strict`

### DIFF
--- a/bosh-init.rb
+++ b/bosh-init.rb
@@ -1,8 +1,8 @@
 class BoshInit < Formula
-  desc "creates and updates the Director VM"
+  desc "Creates and updates the Director VM"
   homepage "https://github.com/cloudfoundry/bosh-init"
-  version "0.0.99"
   url "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-#{version}-darwin-amd64"
+  version "0.0.99"
   sha256 "3a2f63493ecede7b9d99d46ffd0c99d5c40edd44db6ddd97ffcc52c56b4ebb89"
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
```
cloudfoundry/tap/bosh-init:
 * C: 2: col 9: Description should start with a capital letter
 * C: 5: col 3: `url` (line 5) should be put before `version` (line 4)
```