### PR TITLE
Update CredHub CLI to 2.7.0

### DIFF
--- a/credhub-cli.rb
+++ b/credhub-cli.rb
@@ -1,14 +1,14 @@
 class CredhubCli < Formula
   desc "CredHub CLI"
   homepage "https://github.com/cloudfoundry-incubator/credhub-cli"
-  version "2.6.2"
+  version "2.7.0"
 
   if OS.mac?
-    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.6.2/credhub-darwin-2.6.2.tgz"
-    sha256 "a763d90ca4c9cfd894d0c726c7ab3131061c9002d8ba48ef3b87ac9b6b68c194"
+    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.7.0/credhub-darwin-2.7.0.tgz"
+    sha256 "d76381a967a1cc6d8fdb5c3cd51a513895000b78ed934f569332325c9d16aa8f"
   elsif OS.linux?
-    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.6.2/credhub-linux-2.6.2.tgz"
-    sha256 "897b588d9236d520c4eabec794e6126254f607c506ce6ea77350b60ecfa5c1ce"
+    url "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.7.0/credhub-linux-2.7.0.tgz"
+    sha256 "a453c937caedbd15c30a348a6fd4a717bb321ce7c077d137ef2ea28eb8befb8b"
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
For whatever reason, it doesn't look like the CF CredHub CI Pipeline has kicked this over.  Submitting PR manually.