### PR TITLE
Added Linux install option for bosh-cli

### DIFF
--- a/bosh-cli.rb
+++ b/bosh-cli.rb
@@ -1,17 +1,29 @@
+require 'formula'
+
 class BoshCli < Formula
   desc "New BOSH CLI (beta)"
   homepage "https://bosh.io/docs/cli-v2.html"
   version "6.2.1"
-  url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-amd64"
-  sha256 "1d2ced5edc7a9406616df7ad9c0d4e3ade10d66d33e753885ab8e245c037e280"
-
+  
+  if OS.mac?
+    url "https://github.com/cloudfoundry/bosh-cli/releases/download/v#{version}/bosh-cli-#{version}-darwin-amd64"
+    sha256 '1d2ced5edc7a9406616df7ad9c0d4e3ade10d66d33e753885ab8e245c037e280'
+  elsif OS.linux?
+    url "https://github.com/cloudfoundry/bosh-cli/releases/download/v#{version}/bosh-cli-#{version}-linux-amd64"
+    sha256 'ca7580008abfd4942dcb1dd6218bde04d35f727717a7d08a2bc9f7d346bce0f6'
+  end
+  
   depends_on :arch => :x86_64
 
   option "with-bosh2", "Rename binary to 'bosh2'. Useful if the old Ruby CLI is needed."
 
   def install
     binary_name = build.with?("bosh2") ? "bosh2" : "bosh"
-    bin.install "bosh-cli-#{version}-darwin-amd64" => binary_name
+    if OS.mac?
+      bin.install "bosh-cli-#{version}-darwin-amd64" => binary_name
+    elsif OS.linux?
+      bin.install "bosh-cli-#{version}-linux-amd64" => binary_name
+    end
     (bash_completion/"bosh-cli").write <<-completion
       _#{binary_name}() {
           # All arguments except the first one


### PR DESCRIPTION
Simple rewrite of the bosh-cli formula to support Linux installations as well. Written in the same style as the other formulae in this tap.