### PR TITLE
Add cf-cli@6 formula and all previous versions

### DIFF
--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.23.1&source=homebrew'
-  version '6.23.1'
-  sha256 'aee12111e7403f97270c59bd2f05551f6b23a30729843ce92a5422d0f319ab60'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.24.0&source=homebrew'
+  version '6.24.0'
+  sha256 'fb1e9e050d63146efd9f9fdcde24cc192e4760d2a79bf8311ed48f13479254c2'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.36.0'
+  version '6.36.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.36.0&source=homebrew'
-    sha256 'db26ec52b74523fc875b44f9a05fe3c0a88680dce0126770aea38422dc7e6834'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.36.1&source=homebrew'
+    sha256 'f787217e4aea5266666c035b70bc524d4827377e75f253d349f8ef3071bb4bf5'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.36.0&source=homebrew'
-    sha256 'd88dc82a40204cb48825d2420281fa916219560b26588801628853a18f17b88c'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.36.1&source=homebrew'
+    sha256 'd5e59258183939305f44c471dab41a000290446399cc9b206b107c7bdb8ce180'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.44.0'
+  version '6.44.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.44.0.tgz'
-    sha256 '8ac01fd35ad1eb96b8a4d11fbd52ed802a403e637d4105a0f562e64e64db8ac1'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.44.1.tgz'
+    sha256 '2f9e775c1a3c92199cb2f0b41d4bb95a010ae289f7bd56644b0484a7ddd6e605'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.44.0&source=homebrew'
-    sha256 '3e45dee13bbfa23565119df126dae043a8aca574fbf309b2ca73ba24e7e77692'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.44.1&source=homebrew'
+    sha256 'b986a55fef4bd6f580d7a070f4592362309fe009ffdd9489b9d3b871aed07aa3'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.2&source=homebrew'
-  version '6.22.2'
-  sha256 '60f3f2a7b3a0312951bef207b43864cc65974d86a57c8bedbf3470cf2b18303d'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.1&source=homebrew'
+  version '6.22.1'
+  sha256 '2da08e15223147d87caf51bc7fff6eb224c3a194d57052e69f3bc2ba05209541'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -14,8 +14,8 @@ class CfCliAT6 < Formula
 
   def install
     bin.install 'cf'
-    (bash_completion/"cf-cli").write <<-completion
-      _cf-cli() {
+    (bash_completion/"cf").write <<-completion
+      _cf() {
           # All arguments except the first one
           args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
           # Only split on newlines
@@ -25,7 +25,7 @@ class CfCliAT6 < Formula
           COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
           return 0
       }
-      complete -F _cf-cli cf
+      complete -F _cf cf
     completion
     doc.install 'LICENSE'
     doc.install 'NOTICE'

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 '86d5938f447f762096faa8c0c130d702fa27adfb7603b6fe9b159b1db23d83e8'
+  sha256 '65fbc02b8a10579c2f8d7bfd0afd3c89734eff9fb6ff4867be0632209089e9cc'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,8 +3,8 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.1&source=homebrew'
-  version '6.22.1'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.23.0&source=homebrew'
+  version '6.23.0'
   sha256 '2da08e15223147d87caf51bc7fff6eb224c3a194d57052e69f3bc2ba05209541'
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.50.0'
+  version '6.51.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.50.0.tgz'
-    sha256 '8fa562c757a914facd5f7c2a79e7fa33d32ea1a46e69e69a09725dfc854e33c7'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.51.0.tgz'
+    sha256 'e3c0319058f623c0607039bcf40e6378cc1eee8dba0ab49571813aa0142fbe5f'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.50.0&source=homebrew'
-    sha256 '848a3521fb2b1621b687cfa3333636a04a901799a38cffeeca2134a993ee522d'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.51.0&source=homebrew'
+    sha256 'cf49127bf52c139e608d76424c77aa0123291897ac6d121a432bdad4ba7a4b58'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.24.0&source=homebrew'
-  version '6.24.0'
-  sha256 'fb1e9e050d63146efd9f9fdcde24cc192e4760d2a79bf8311ed48f13479254c2'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.25.0&source=homebrew'
+  version '6.25.0'
+  sha256 'c2383a5c51176dc836ef571acfb5a5f3415c783f9d3f45f3984a6041c191b276'
 
   depends_on :arch => :x86_64
 
@@ -14,18 +14,20 @@ class CfCliAT6 < Formula
 
   def install
     bin.install 'cf'
-    (bash_completion/"cf").write <<-completion
-      _cf() {
-          # All arguments except the first one
-          args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
-          # Only split on newlines
-          local IFS=$'\n'
-          # Call completion (note that the first element of COMP_WORDS is
-          # the executable itself)
-          COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
-          return 0
-      }
-      complete -F _cf cf
+    (bash_completion/"cf-cli").write <<-completion
+# bash completion for Cloud Foundry CLI
+
+_cf-cli() {
+    # All arguments except the first one
+    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    # Only split on newlines
+    local IFS=$'\n'
+    # Call completion (note that the first element of COMP_WORDS is
+    # the executable itself)
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+    return 0
+}
+complete -F _cf-cli cf
     completion
     doc.install 'LICENSE'
     doc.install 'NOTICE'

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.31.0&source=homebrew'
-  version '6.31.0'
-  sha256 '7b3ddb249da14f7142abf1801cc4908821985552841eff34c45a3fadf18aa934'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
+  version '6.32.0'
+  sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.26.0&source=homebrew'
-  version '6.26.0'
-  sha256 '5802f5c59d36001a27e4cb6ef95001e4037deaaf69d7800611049ed71ac421a6'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.27.0&source=homebrew'
+  version '6.27.0'
+  sha256 '76a4fe68005f01f9fba87d1d9087857a1d3ec06a951bb5e232e07bd47f6a52a8'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,14 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
   version '6.32.0'
-  sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
+  if OS.mac?
+    url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
+    sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
+  elsif OS.linux?
+    url 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0&source=homebrew'
+    sha256 '0a05521b7198dc8b92efbfb02a8fb04c84eeffeded3387aa3c9eb92ce4abef69'
+  end
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 '68dc2a74a823ebc8bb2cd4ed411d0db8d3e3b544fa127b27bcd9e2472150cf1a'
+  sha256 '86d5938f447f762096faa8c0c130d702fa27adfb7603b6fe9b159b1db23d83e8'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.44.1'
+  version '6.45.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.44.1.tgz'
-    sha256 '2f9e775c1a3c92199cb2f0b41d4bb95a010ae289f7bd56644b0484a7ddd6e605'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.45.0.tgz'
+    sha256 '4e778621b810025ee9444e2acf301d4b95d6383a8605cbec9452381bdfbed7f3'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.44.1&source=homebrew'
-    sha256 'b986a55fef4bd6f580d7a070f4592362309fe009ffdd9489b9d3b871aed07aa3'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.45.0&source=homebrew'
+    sha256 '57499442f109e7a28887f75eae7c4b10a46021f3aa5a76290f7e35e5d1280218'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.37.0'
+  version '6.38.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.37.0&source=homebrew'
-    sha256 'f1d54650c2b326878672e328c8c738b6bfbffcb0723cc0062715585bdd9d1c82'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.38.0&source=homebrew'
+    sha256 '0f7f78a9b4cdfc12b373f61269cc86285b6f56f8458538b35a8d38a3437d0ff2'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.37.0&source=homebrew'
-    sha256 'a9f34cb87572eca678b89f7303fe960059347373bb59f82411433a8ef5638445'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.38.0&source=homebrew'
+    sha256 '846b9f1746c8e9cfaf11891950536fb805b1a02975c99e8c4e02328d40020604'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.46.0'
+  version '6.46.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.46.0.tgz'
-    sha256 'd56cf2fb913ed26ede4cca8975ed4be86e5177c4abfc7dfb32e626f4c90d78b6'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.46.1.tgz'
+    sha256 '36d21735ede169efe53335d72ff5a1286c60eda70451cb71d97c48a7e471144b'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.46.0&source=homebrew'
-    sha256 '3dc504c790dc7984af4aeff360b8cb5df73f252728f2ae0a620fa4cfb31b6c88'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.46.1&source=homebrew'
+    sha256 '17a54a359d23b32b791fc7c32cc72af32cff3b515866eada03a1a8b984446722'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.41.0'
+  version '6.42.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.41.0.tgz'
-    sha256 'f882c025ba5887c8942055b8a641261d729fec08c35da14290fc5423b9af9f80'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.42.0.tgz'
+    sha256 '4deed9d820326f03d1afaeacb74f182160e21eb0948c8ecf9d5f4f37c06ad186'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.41.0&source=homebrew'
-    sha256 'eedf8567e6a94570ccabc51653eec2a4c739702e03997e21ebfd2f855bb8c18c'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.42.0&source=homebrew'
+    sha256 '39940520903076fb5163a245bf64e24cb52624e3a5f8625eac16aebded6c0041'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -16,9 +16,6 @@ class CfCliAT6 < Formula
 
   depends_on :arch => :x86_64
 
-  conflicts_with "pivotal/tap/cloudfoundry-cli", :because => "the Pivotal tap ships an older cli distribution"
-  conflicts_with "caskroom/cask/cloudfoundry-cli", :because => "the caskroom tap is not the official distribution"
-
   def install
     bin.install 'cf'
     (bash_completion/"cf-cli").write <<-completion

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.30.0&source=homebrew'
-  version '6.30.0'
-  sha256 'd3524f3c8d2809307166fcea2dc90683d2cf783e4930bcba60aaaed0e702387f'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.31.0&source=homebrew'
+  version '6.31.0'
+  sha256 '7b3ddb249da14f7142abf1801cc4908821985552841eff34c45a3fadf18aa934'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,19 +2,22 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.33.0'
+  version '6.33.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.33.0&source=homebrew'
-    sha256 '3ef382ba18ce7460e9f5a697d4742e358d5c04a3164191c626c0c6826b07a6b8'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.33.1&source=homebrew'
+    sha256 '3721ae9956e3b623500d81b670a4467e73485be0e3855c48c167c7085beb83bf'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.33.0&source=homebrew'
-    sha256 '443b61459bed73571e987f5c09ac559278da68fffa62ebe521d770d00b8f5629'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.33.1&source=homebrew'
+    sha256 '09b19125d73f9eb1ffca22eeb62ee62b224180e37a2c8ff0a1a63a9325a04e04'
   end
 
   depends_on :arch => :x86_64
+
+  conflicts_with "pivotal/tap/cloudfoundry-cli", :because => "the Pivotal tap ships an older cli distribution"
+  conflicts_with "caskroom/cask/cloudfoundry-cli", :because => "the caskroom tap is not the official distribution"
 
   def install
     bin.install 'cf'

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -6,7 +6,7 @@ class CfCliAT6 < Formula
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.38.0&source=homebrew'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.38.0.tgz'
     sha256 '0f7f78a9b4cdfc12b373f61269cc86285b6f56f8458538b35a8d38a3437d0ff2'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.1&source=homebrew'
-  version '6.22.1'
-  sha256 '7171fe38fe526001e380ad932088ce174d0b6cb9f9a28932ada84e3dd377fc11'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.2&source=homebrew'
+  version '6.22.2'
+  sha256 '60f3f2a7b3a0312951bef207b43864cc65974d86a57c8bedbf3470cf2b18303d'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.0&source=homebrew'
-  version '6.22.0'
-  sha256 '6c38c315cfc94926ccfeb56c1f2082227a8cba2a98737d90f1bf3294ddaa19e5'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.1&source=homebrew'
+  version '6.22.1'
+  sha256 '7171fe38fe526001e380ad932088ce174d0b6cb9f9a28932ada84e3dd377fc11'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.40.1'
+  version '6.41.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.40.1.tgz'
-    sha256 '9783aee1a4505d9fa44723dae8a40264575ebfeb37795aa11513729bbee33ab4'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.41.0.tgz'
+    sha256 'f882c025ba5887c8942055b8a641261d729fec08c35da14290fc5423b9af9f80'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.40.1&source=homebrew'
-    sha256 '0693f87042c0d2c9e224dd5604351a7d4b036736ccabd33eb950babba66f4bc6'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.41.0&source=homebrew'
+    sha256 'eedf8567e6a94570ccabc51653eec2a4c739702e03997e21ebfd2f855bb8c18c'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.29.0&source=homebrew'
-  version '6.29.0'
-  sha256 '09301eebe859e8ad0400e9762a0c8a8f7a5f2d1c8036cd29b677e91e2d9b354d'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.29.1&source=homebrew'
+  version '6.29.1'
+  sha256 '9aec3a9dea08b2f81d0b9893f3bd870a6c27d3e7e6ebc8773ac062a29affaa32'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.45.0'
+  version '6.46.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.45.0.tgz'
-    sha256 '4e778621b810025ee9444e2acf301d4b95d6383a8605cbec9452381bdfbed7f3'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.46.0.tgz'
+    sha256 'd56cf2fb913ed26ede4cca8975ed4be86e5177c4abfc7dfb32e626f4c90d78b6'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.45.0&source=homebrew'
-    sha256 '57499442f109e7a28887f75eae7c4b10a46021f3aa5a76290f7e35e5d1280218'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.46.0&source=homebrew'
+    sha256 '3dc504c790dc7984af4aeff360b8cb5df73f252728f2ae0a620fa4cfb31b6c88'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.40.0'
+  version '6.40.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.40.0.tgz'
-    sha256 '31bf7ac8e6bd191ddf7f4bd2dc50d136ab2b76b3aaa6baa69923aa86d472bd4a'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.40.1.tgz'
+    sha256 '9783aee1a4505d9fa44723dae8a40264575ebfeb37795aa11513729bbee33ab4'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.40.0&source=homebrew'
-    sha256 'de34bb9755ec9f9ca9605b14c690a9013157cc3c83fc647beb2c842a03c8b5b2'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.40.1&source=homebrew'
+    sha256 '0693f87042c0d2c9e224dd5604351a7d4b036736ccabd33eb950babba66f4bc6'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.27.0&source=homebrew'
-  version '6.27.0'
-  sha256 '76a4fe68005f01f9fba87d1d9087857a1d3ec06a951bb5e232e07bd47f6a52a8'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.28.0&source=homebrew'
+  version '6.28.0'
+  sha256 '7bbc449c4ad587864bb44905a60b7cae725d535a8224a9c7f384be299134ceef'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.25.0&source=homebrew'
-  version '6.25.0'
-  sha256 'c2383a5c51176dc836ef571acfb5a5f3415c783f9d3f45f3984a6041c191b276'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.26.0&source=homebrew'
+  version '6.26.0'
+  sha256 '5802f5c59d36001a27e4cb6ef95001e4037deaaf69d7800611049ed71ac421a6'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -1,6 +1,7 @@
 require 'formula'
 
 class CfCliAT6 < Formula
+  desc "The official command line client for Cloud Foundry"
   homepage 'https://code.cloudfoundry.org/cli'
   version '6.51.0'
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.35.1'
+  version '6.35.2'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.35.1&source=homebrew'
-    sha256 '2f2424f0b843395c6a47442b06d49dbf8605d0cd7c56c8512be3eebc24a4714a'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.35.2&source=homebrew'
+    sha256 '2e57da01baea8547a228592df180e53cf7e7a815c387491a2fcd0503f7ae7d4b'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.35.1&source=homebrew'
-    sha256 'ab9b8d2b15b3ec215cf829e4585109de510992e3b3db00c9ce4845332bbf16b1'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.35.2&source=homebrew'
+    sha256 '708a7757d3b3192a40e2cd8073b4f20afc59b7cbb0cb6bd88244268dfc6eb77d'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.28.0&source=homebrew'
-  version '6.28.0'
-  sha256 '7bbc449c4ad587864bb44905a60b7cae725d535a8224a9c7f384be299134ceef'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.29.0&source=homebrew'
+  version '6.29.0'
+  sha256 '09301eebe859e8ad0400e9762a0c8a8f7a5f2d1c8036cd29b677e91e2d9b354d'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.36.2'
+  version '6.37.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.36.2&source=homebrew'
-    sha256 'e46b1635d324b96bda2adef5b480bec4474da1e9c359c75e2b2686750d119b18'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.37.0&source=homebrew'
+    sha256 'f1d54650c2b326878672e328c8c738b6bfbffcb0723cc0062715585bdd9d1c82'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.36.2&source=homebrew'
-    sha256 '21692bcc2cc2089e995dd15d0ce8d6f53c8801ced9e19f264d4a7d6aadd06aa4'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.37.0&source=homebrew'
+    sha256 'a9f34cb87572eca678b89f7303fe960059347373bb59f82411433a8ef5638445'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.39.0'
+  version '6.39.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.39.0.tgz'
-    sha256 'ce849831c0792cabe751fea50bd8188fbaca3937d6a847b887234057ae6b2c36'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.39.1.tgz'
+    sha256 '5736d6f74d4f04386d7d3246833d660cedd5bc9c229a59687e1535a2fd252ffa'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.39.0&source=homebrew'
-    sha256 '11750f3257802ecb9407e99645908904c017816ac451cebd9ec8d266f3d6382f'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.39.1&source=homebrew'
+    sha256 '62c3930b139c71334ad6b69fddc7fa469558873995877ed8bbfdf07e170d1d3e'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.34.0'
+  version '6.34.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.34.0&source=homebrew'
-    sha256 '2ad9dcc7c272da7ac3f684823e1ae71945b04dcbe0a4c70fe70589d62956a3c2'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.34.1&source=homebrew'
+    sha256 '5f604d76b805f1a6e3c6cbad1a829b3f9fcbf677e9bf5fd53c341321fef56c1c'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.34.0&source=homebrew'
-    sha256 'b9174b43007cb2cfc0e88a2304e1cc8434fd07b99f51e1b1278eecfa57dcf25f'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.34.1&source=homebrew'
+    sha256 '95f25b19ad7645124752072b595ae9e7df66fc7fb48f633b63e7d9d7a9e0b1bc'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.36.1'
+  version '6.36.2'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.36.1&source=homebrew'
-    sha256 'f787217e4aea5266666c035b70bc524d4827377e75f253d349f8ef3071bb4bf5'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.36.2&source=homebrew'
+    sha256 'e46b1635d324b96bda2adef5b480bec4474da1e9c359c75e2b2686750d119b18'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.36.1&source=homebrew'
-    sha256 'd5e59258183939305f44c471dab41a000290446399cc9b206b107c7bdb8ce180'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.36.2&source=homebrew'
+    sha256 '21692bcc2cc2089e995dd15d0ce8d6f53c8801ced9e19f264d4a7d6aadd06aa4'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 'f37e0d3028f77836019adc2096ac347d45d4cebf0f3c36194ca982bbdb67a906'
+  sha256 '5cc3b403b672ac9097d4386f3732cd7d5dc7eebea302206996be276c8d91ac94'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.47.2'
+  version '6.48.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.47.2.tgz'
-    sha256 'dfe3d7ec65ac380f0f8f72994a8764c5f5d5e65f83bc56bd7700862b9b3c7e6e'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.48.0.tgz'
+    sha256 '5197f2c9e1e31437f0e18807260078aa1e56a8f5d5f153b58586b5839b1c8e71'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.2&source=homebrew'
-    sha256 'b9cd5c866259b6e3d6b22a1dd00c3ee5ed9b599fb40a143be0ced116e8631a81'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.48.0&source=homebrew'
+    sha256 '70ffba5d848e0637b6e2b91818a95d6c5eefe410237233ddcfcef197c175d447'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -14,6 +14,19 @@ class CfCliAT6 < Formula
 
   def install
     bin.install 'cf'
+    (bash_completion/"cf-cli").write <<-completion
+      _cf-cli() {
+          # All arguments except the first one
+          args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+          # Only split on newlines
+          local IFS=$'\n'
+          # Call completion (note that the first element of COMP_WORDS is
+          # the executable itself)
+          COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+          return 0
+      }
+      complete -F _cf-cli cf
+    completion
     doc.install 'LICENSE'
     doc.install 'NOTICE'
   end

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,14 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
   version '6.32.0'
-  if OS.mac?
-    url "https://cli.run.pivotal.io/stable?release=macosx64-binary&version=#{version}&source=homebrew"
-    sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
-  elsif OS.linux?
-    url "https://cli.run.pivotal.io/stable?release=linux64-binary&version=#{version}&source=homebrew"
-    sha256 '0a05521b7198dc8b92efbfb02a8fb04c84eeffeded3387aa3c9eb92ce4abef69'
-  end
+  sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.49.0'
+  version '6.50.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.49.0.tgz'
-    sha256 '7dc6f0e32358b86016a97c3e5c987024169cac5512df1a548aceab9ebad316c7'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.50.0.tgz'
+    sha256 '8fa562c757a914facd5f7c2a79e7fa33d32ea1a46e69e69a09725dfc854e33c7'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.49.0&source=homebrew'
-    sha256 'fafcd4a701897c5eb44168ca7bd0c4502e442ea65324ffaca71b0a4b344c9a99'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.50.0&source=homebrew'
+    sha256 '848a3521fb2b1621b687cfa3333636a04a901799a38cffeeca2134a993ee522d'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,10 +2,17 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
-  version '6.32.0'
-  sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
+  version '6.33.0'
+
+  if OS.mac?
+    head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.33.0&source=homebrew'
+    sha256 '3ef382ba18ce7460e9f5a697d4742e358d5c04a3164191c626c0c6826b07a6b8'
+  elsif OS.linux?
+    head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.33.0&source=homebrew'
+    sha256 '443b61459bed73571e987f5c09ac559278da68fffa62ebe521d770d00b8f5629'
+  end
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.42.0'
+  version '6.43.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.42.0.tgz'
-    sha256 '4deed9d820326f03d1afaeacb74f182160e21eb0948c8ecf9d5f4f37c06ad186'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.43.0.tgz'
+    sha256 '2e9797c9f9de2e916641243f377f10fd4c9df92e823ab57b2775d4b89b7f5f10'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.42.0&source=homebrew'
-    sha256 '39940520903076fb5163a245bf64e24cb52624e3a5f8625eac16aebded6c0041'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.43.0&source=homebrew'
+    sha256 '19f18b7439b7cf625c7a7e2a048f3e8b0caba7a7d6a1455e2afbb48ff6f2e117'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.39.1'
+  version '6.40.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.39.1.tgz'
-    sha256 '5736d6f74d4f04386d7d3246833d660cedd5bc9c229a59687e1535a2fd252ffa'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.40.0.tgz'
+    sha256 '31bf7ac8e6bd191ddf7f4bd2dc50d136ab2b76b3aaa6baa69923aa86d472bd4a'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.39.1&source=homebrew'
-    sha256 '62c3930b139c71334ad6b69fddc7fa469558873995877ed8bbfdf07e170d1d3e'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.40.0&source=homebrew'
+    sha256 'de34bb9755ec9f9ca9605b14c690a9013157cc3c83fc647beb2c842a03c8b5b2'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.47.0'
+  version '6.47.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.47.0.tgz'
-    sha256 '29613a5c55c3c4b020e08a1f73a23f4fc1157d07de6da170a8afa901acdbc09b'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.47.1.tgz'
+    sha256 '0ddb7d0dc11e6007003cd6ff074992493252791d71f4c41651b68e49ed2771f8'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.0&source=homebrew'
-    sha256 'c8ec2b8044f5ccf75c98e3da55e54e72cb27fd7ea417aaae705c299d2aa8c20e'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.1&source=homebrew'
+    sha256 '09ccc230324fc3c68d1ac7f400fd731b8f236c385eb49edd02116f1a2a26d437'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.35.2'
+  version '6.36.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.35.2&source=homebrew'
-    sha256 '2e57da01baea8547a228592df180e53cf7e7a815c387491a2fcd0503f7ae7d4b'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.36.0&source=homebrew'
+    sha256 'db26ec52b74523fc875b44f9a05fe3c0a88680dce0126770aea38422dc7e6834'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.35.2&source=homebrew'
-    sha256 '708a7757d3b3192a40e2cd8073b4f20afc59b7cbb0cb6bd88244268dfc6eb77d'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.36.0&source=homebrew'
+    sha256 'd88dc82a40204cb48825d2420281fa916219560b26588801628853a18f17b88c'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.47.1'
+  version '6.47.2'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.47.1.tgz'
-    sha256 '0ddb7d0dc11e6007003cd6ff074992493252791d71f4c41651b68e49ed2771f8'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.47.2.tgz'
+    sha256 'dfe3d7ec65ac380f0f8f72994a8764c5f5d5e65f83bc56bd7700862b9b3c7e6e'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.1&source=homebrew'
-    sha256 '09ccc230324fc3c68d1ac7f400fd731b8f236c385eb49edd02116f1a2a26d437'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.2&source=homebrew'
+    sha256 'b9cd5c866259b6e3d6b22a1dd00c3ee5ed9b599fb40a143be0ced116e8631a81'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.23.0&source=homebrew'
-  version '6.23.0'
-  sha256 '2da08e15223147d87caf51bc7fff6eb224c3a194d57052e69f3bc2ba05209541'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.23.1&source=homebrew'
+  version '6.23.1'
+  sha256 'aee12111e7403f97270c59bd2f05551f6b23a30729843ce92a5422d0f319ab60'
 
   depends_on :arch => :x86_64
 
@@ -14,6 +14,8 @@ class CfCliAT6 < Formula
 
   def install
     bin.install 'cf'
+    doc.install 'LICENSE'
+    doc.install 'NOTICE'
   end
 
   test do

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.35.0'
+  version '6.35.1'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.35.0&source=homebrew'
-    sha256 '8246ba69285f7aee3a2e2abe0962fb7d4bc3397626cc2cd02a5ea597343a6bab'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.35.1&source=homebrew'
+    sha256 '2f2424f0b843395c6a47442b06d49dbf8605d0cd7c56c8512be3eebc24a4714a'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.35.0&source=homebrew'
-    sha256 '9d2c1b73616fa7b22c51d6102dcfa20cd7fa73a2352b697ae180a3922ed3f6e1'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.35.1&source=homebrew'
+    sha256 'ab9b8d2b15b3ec215cf829e4585109de510992e3b3db00c9ce4845332bbf16b1'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.46.1'
+  version '6.47.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.46.1.tgz'
-    sha256 '36d21735ede169efe53335d72ff5a1286c60eda70451cb71d97c48a7e471144b'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.47.0.tgz'
+    sha256 '29613a5c55c3c4b020e08a1f73a23f4fc1157d07de6da170a8afa901acdbc09b'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.46.1&source=homebrew'
-    sha256 '17a54a359d23b32b791fc7c32cc72af32cff3b515866eada03a1a8b984446722'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.0&source=homebrew'
+    sha256 'c8ec2b8044f5ccf75c98e3da55e54e72cb27fd7ea417aaae705c299d2aa8c20e'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.29.1&source=homebrew'
-  version '6.29.1'
-  sha256 '9aec3a9dea08b2f81d0b9893f3bd870a6c27d3e7e6ebc8773ac062a29affaa32'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.29.2&source=homebrew'
+  version '6.29.2'
+  sha256 '9ce3f8d85490bf999683334d367fc39eb24c652a57e26f8f62834176ce9e7eaf'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 '5cc3b403b672ac9097d4386f3732cd7d5dc7eebea302206996be276c8d91ac94'
+  sha256 'bdaa90c3e0341f924a163fd1f7ca52a09f514f6d90b2b170a5ecadbfae18bdae'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.29.2&source=homebrew'
-  version '6.29.2'
-  sha256 '9ce3f8d85490bf999683334d367fc39eb24c652a57e26f8f62834176ce9e7eaf'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.30.0&source=homebrew'
+  version '6.30.0'
+  sha256 'd3524f3c8d2809307166fcea2dc90683d2cf783e4930bcba60aaaed0e702387f'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,10 +5,10 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   version '6.32.0'
   if OS.mac?
-    url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.32.0&source=homebrew'
+    url "https://cli.run.pivotal.io/stable?release=macosx64-binary&version=#{version}&source=homebrew"
     sha256 'ddbe83ac8cfe6249431d5a50d5193d127d840fa592261b7050accc2b9757d727'
   elsif OS.linux?
-    url 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0&source=homebrew'
+    url "https://cli.run.pivotal.io/stable?release=linux64-binary&version=#{version}&source=homebrew"
     sha256 '0a05521b7198dc8b92efbfb02a8fb04c84eeffeded3387aa3c9eb92ce4abef69'
   end
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 '7e999d34790514f9c8dd19e6529cad06975ce1377ef4b138490faa78554bf3bc'
+  sha256 '68dc2a74a823ebc8bb2cd4ed411d0db8d3e3b544fa127b27bcd9e2472150cf1a'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.34.1'
+  version '6.35.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.34.1&source=homebrew'
-    sha256 '5f604d76b805f1a6e3c6cbad1a829b3f9fcbf677e9bf5fd53c341321fef56c1c'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.35.0&source=homebrew'
+    sha256 '8246ba69285f7aee3a2e2abe0962fb7d4bc3397626cc2cd02a5ea597343a6bab'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.34.1&source=homebrew'
-    sha256 '95f25b19ad7645124752072b595ae9e7df66fc7fb48f633b63e7d9d7a9e0b1bc'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.35.0&source=homebrew'
+    sha256 '9d2c1b73616fa7b22c51d6102dcfa20cd7fa73a2352b697ae180a3922ed3f6e1'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 'bdaa90c3e0341f924a163fd1f7ca52a09f514f6d90b2b170a5ecadbfae18bdae'
+  sha256 '862701337dc3892382dea2b1f6a92ad4cf2baadb464dec0a81e982bfe8b2f793'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.48.0'
+  version '6.49.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.48.0.tgz'
-    sha256 '5197f2c9e1e31437f0e18807260078aa1e56a8f5d5f153b58586b5839b1c8e71'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.49.0.tgz'
+    sha256 '7dc6f0e32358b86016a97c3e5c987024169cac5512df1a548aceab9ebad316c7'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.48.0&source=homebrew'
-    sha256 '70ffba5d848e0637b6e2b91818a95d6c5eefe410237233ddcfcef197c175d447'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.49.0&source=homebrew'
+    sha256 'fafcd4a701897c5eb44168ca7bd0c4502e442ea65324ffaca71b0a4b344c9a99'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 '862701337dc3892382dea2b1f6a92ad4cf2baadb464dec0a81e982bfe8b2f793'
+  sha256 '7e999d34790514f9c8dd19e6529cad06975ce1377ef4b138490faa78554bf3bc'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.38.0'
+  version '6.39.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.38.0.tgz'
-    sha256 '0f7f78a9b4cdfc12b373f61269cc86285b6f56f8458538b35a8d38a3437d0ff2'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.39.0.tgz'
+    sha256 'ce849831c0792cabe751fea50bd8188fbaca3937d6a847b887234057ae6b2c36'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.38.0&source=homebrew'
-    sha256 '846b9f1746c8e9cfaf11891950536fb805b1a02975c99e8c4e02328d40020604'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.39.0&source=homebrew'
+    sha256 '11750f3257802ecb9407e99645908904c017816ac451cebd9ec8d266f3d6382f'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.33.1'
+  version '6.34.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.33.1&source=homebrew'
-    sha256 '3721ae9956e3b623500d81b670a4467e73485be0e3855c48c167c7085beb83bf'
+    url 'https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=6.34.0&source=homebrew'
+    sha256 '2ad9dcc7c272da7ac3f684823e1ae71945b04dcbe0a4c70fe70589d62956a3c2'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.33.1&source=homebrew'
-    sha256 '09b19125d73f9eb1ffca22eeb62ee62b224180e37a2c8ff0a1a63a9325a04e04'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.34.0&source=homebrew'
+    sha256 'b9174b43007cb2cfc0e88a2304e1cc8434fd07b99f51e1b1278eecfa57dcf25f'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -1,11 +1,11 @@
 require 'formula'
 
 class CfCliAT6 < Formula
-  homepage 'https://github.com/cloudfoundry/cli'
+  homepage 'https://code.cloudfoundry.org/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
-  version '6.21.1'
-  sha256 '0faca62b5983260a371a08af8c5cb73d66ca324da16a4225789f2a479107ff18'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.22.0&source=homebrew'
+  version '6.22.0'
+  sha256 '6c38c315cfc94926ccfeb56c1f2082227a8cba2a98737d90f1bf3294ddaa19e5'
 
   depends_on :arch => :x86_64
 

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -2,16 +2,16 @@ require 'formula'
 
 class CfCliAT6 < Formula
   homepage 'https://code.cloudfoundry.org/cli'
-  version '6.43.0'
+  version '6.44.0'
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.43.0.tgz'
-    sha256 '2e9797c9f9de2e916641243f377f10fd4c9df92e823ab57b2775d4b89b7f5f10'
+    url 'https://packages.cloudfoundry.org/homebrew/cf-6.44.0.tgz'
+    sha256 '8ac01fd35ad1eb96b8a4d11fbd52ed802a403e637d4105a0f562e64e64db8ac1'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.43.0&source=homebrew'
-    sha256 '19f18b7439b7cf625c7a7e2a048f3e8b0caba7a7d6a1455e2afbb48ff6f2e117'
+    url 'https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.44.0&source=homebrew'
+    sha256 '3e45dee13bbfa23565119df126dae043a8aca574fbf309b2ca73ba24e7e77692'
   end
 
   depends_on :arch => :x86_64

--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -5,7 +5,7 @@ class CfCliAT6 < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.21.1&source=homebrew'
   version '6.21.1'
-  sha256 '65fbc02b8a10579c2f8d7bfd0afd3c89734eff9fb6ff4867be0632209089e9cc'
+  sha256 '0faca62b5983260a371a08af8c5cb73d66ca324da16a4225789f2a479107ff18'
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
As part of the plan to GA CF CLI v7 we wanted: 
- to create a `cf-cli@6` formula for Brew users to pull from if they want to consume the latest v6 cli releases without pulling in v7 releases
- enable users to pin to specific old versions of the v6 CF CLI through the new `cf-cli@6` formula

This PR recreates the entire history of the v6 CLI in brew under the new `cf-cli@6` formula. 

Question: Why are there 97 commits? 
Answer: This PR recreates the entire history of the v6 CLI in brew under the new `cf-cli@6` formula. The homebrew command `brew extract` is used to pin to old versions of a formula and relies on the git history.

Question: Why didn't we rename the existing `cf-cli` formula?
Answer: We are going to re-purpose the `cf-cli` formula to install the mainline CF CLI (which will soon be v7 and eventually v8). We want users who are already using `cf-cli` to be automatically upgraded to v7, and users who specifically only want v6 to switch to the new formula.

[172870853](https://www.pivotaltracker.com/story/show/172870853)