### PR TITLE
Support M1 silicon

### DIFF
--- a/cf-cli.rb
+++ b/cf-cli.rb
@@ -14,8 +14,6 @@ class CfCli < Formula
     sha256 '09664d1469fb8a0ddba804343121aba7d8f64ba6bfde75a53f6e29d6600b2342'
   end
 
-  depends_on :arch => :x86_64
-
   def install
     bin.install 'cf'
     (bash_completion/"cf-cli").write <<-completion


### PR DESCRIPTION
cf-cli is a go binary and can be easily built on ARM.

The only thing preventing it was this declaration in the homebrew
formula.

Fixes cloudfoundry/homebrew-tap#74, cloudfoundry/cli#2131.