### PR TITLE
fix macos cf-cli@6 404 error

### DIFF
--- a/cf-cli@6.rb
+++ b/cf-cli@6.rb
@@ -7,7 +7,7 @@ class CfCliAT6 < Formula
 
   if OS.mac?
     head 'https://packages.cloudfoundry.org/edge?arch=macosx64&source=homebrew'
-    url 'https://packages.cloudfoundry.org/homebrew/cf-6.53.0.tgz'
+    url 'https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v6.53.0/cf-cli_6.53.0_osx.tgz'
     sha256 '3d5f94759dd4aa135fb10e04c6525f2b747727cbb5789ff1a0aacce365fa9515'
   elsif OS.linux?
     head 'https://packages.cloudfoundry.org/edge?arch=linux64&source=homebrew'


### PR DESCRIPTION
Installing cf-cli
==> Downloading https://packages.cloudfoundry.org/homebrew/cf-6.53.0.tgz
curl: (22) The requested URL returned error: 404
Error: cf-cli: Failed to download resource "cf-cli"
Download failed: https://packages.cloudfoundry.org/homebrew/cf-6.53.0.tgz
Installing cf-cli has failed!