### PR TITLE
Homebrew formula points to new GCS bucket

### DIFF
--- a/bosh-cli.rb
+++ b/bosh-cli.rb
@@ -5,14 +5,14 @@ class BoshCli < Formula
 
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-arm64"
+      url "https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-arm64"
       sha256 "e66a12f25497dea499cf769dd2a804370bb15a2a107db93ed6a06c978c4b26af"
     else
-      url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-amd64"
+      url "https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-#{version}-darwin-amd64"
       sha256 "76a9930d24dbad551a0408c7a55cbc263b08e34f5a2948b9da1c1b9bd8207083"
     end
   elsif OS.linux?
-    url "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-#{version}-linux-amd64"
+    url "https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-#{version}-linux-amd64"
     sha256 "0934cc5403761f029b0449d82b2bcb9cebe6b8b7680db4b4af8b008fa2666c4f"
   end
 


### PR DESCRIPTION
The AWS S3 bucket has been deprecated with the migration of the BOSH CLI pipeline to the Cloud Foundry Foundation; it has been replaced by the new GCS bucket.

This commit fixes installation problems by pointing to the new bucket.

Fixes during `brew install bosh-cli`:

```
Error: bosh-cli: Failed to download resource "bosh-cli"
Download failed: https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-7.5.3-darwin-arm64
```