### PR TITLE
Improve documentation and add Cask installation instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  test-formula:
     runs-on: 	macos-latest
     strategy:
       fail-fast: false
@@ -14,7 +14,6 @@ jobs:
             bbl,
             bbr,
             cf-cli,
-            cf-cli@6,
             cf-cli@7,
             cf-cli@8,
             credhub-cli,
@@ -22,5 +21,17 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v3
-      - run: brew tap cloudfoundry/tap "file://${PWD}"
-      - run: brew install  ${{ matrix.formulae }}
+      - run: brew install --formula cloudfoundry/tap/${{ matrix.formulae }}
+
+  test-cask:
+    runs-on: 	macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cask:
+          [
+            uaa-cli
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - run: brew install --cask cloudfoundry/tap/${{ matrix.cask }}

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This is the repository for Cloud Foundry [Homebrew](http://brew.sh/) packages. H
 
 ## Available packages:
 
-| Package        | Type    | Description                              |
-|:---------------|:--------|:-----------------------------------------|
-| cf-cli@{6,7,8} | formula | The official Cloud Foundry CLI           |
-| bosh-cli       | formula | The official new BOSH CLI                |
-| credhub-cli    | formula | The official CredHub CLI                 |
-| bbl            | formula | The official bosh-bootloader CLI         |
-| bbr            | formula | The official BOSH Backup and Restore CLI |
-| uaa-cli        | cask    | CLI for UAA, written in Go               |
+| Package           | Type    | Description                              |
+|:------------------|:--------|:-----------------------------------------|
+| cf-cli\[@{6,7,8}] | formula | The official Cloud Foundry CLI           |
+| bosh-cli          | formula | The official new BOSH CLI                |
+| credhub-cli       | formula | The official CredHub CLI                 |
+| bbl               | formula | The official bosh-bootloader CLI         |
+| bbr               | formula | The official BOSH Backup and Restore CLI |
+| uaa-cli           | cask    | CLI for UAA, written in Go               |
 
 ## Installation
 
@@ -20,7 +20,7 @@ This is the repository for Cloud Foundry [Homebrew](http://brew.sh/) packages. H
 Most packages are available as formula, which can be installed with:
 
 ```bash
-brew install --formula cloudfoundry/tap/<bbl | bbr | bosh-cli | cf-cli@8 | cf-cli@7 | cf-cli@6 | cf-cli  |credhub-cli >
+brew install --formula cloudfoundry/tap/{bbl,bbr,bosh-cli,cf-cli@8,cf-cli@7,cf-cli@6,cf-cli,credhub-cli}
 ```
 
 ### To install a package, via Cask:
@@ -38,7 +38,7 @@ brew uninstall --force uaa-cli
 
 ## Install All Packages
 
-To install all packages, run:
+To install all (latest) packages, run:
 
 ```bash
 brew trust cloudfoundry/tap

--- a/README.md
+++ b/README.md
@@ -1,27 +1,64 @@
-Cloud Foundry Homebrew Tap
-===
-This is the repository for Cloud Foundry [Homebrew](http://brew.sh/) packages. Homebrew is "the missing package manager for OS X".
+# Cloud Foundry Homebrew Tap
 
-To install a package:
+This is the repository for Cloud Foundry [Homebrew](http://brew.sh/) packages. Homebrew is "The Missing Package Manager for macOS (or Linux)".
 
+## Available packages:
+
+| Package        | Type    | Description                              |
+|:---------------|:--------|:-----------------------------------------|
+| cf-cli@{6,7,8} | formula | The official Cloud Foundry CLI           |
+| bosh-cli       | formula | The official new BOSH CLI                |
+| credhub-cli    | formula | The official CredHub CLI                 |
+| bbl            | formula | The official bosh-bootloader CLI         |
+| bbr            | formula | The official BOSH Backup and Restore CLI |
+| uaa-cli        | cask    | CLI for UAA, written in Go               |
+
+## Installation
+
+### To install a package, via formula:
+
+Most packages are available as formula, which can be installed with:
+
+```bash
+brew install --formula cloudfoundry/tap/<bbl | bbr | bosh-cli | cf-cli@8 | cf-cli@7 | cf-cli@6 | cf-cli  |credhub-cli >
 ```
-brew tap cloudfoundry/tap
-brew install <bbl | bbr | bosh-cli | cf-cli | credhub-cli | uaa-cli>
+
+### To install a package, via Cask:
+
+The UAA CLI is available via Cask, which can be installed with:
+
+```bash
+brew install --cask cloudfoundry/tap/uaa-cli
 ```
 
-Available packages:
+If upgrading from the old formula-based version, uninstall it first
+```bash
+brew uninstall --force uaa-cli
+```
 
-| Package     | Description                                                |
-|:------------|:-----------------------------------------------------------|
-| cf-cli      | The official Cloud Foundry CLI                             |
-| bosh-cli    | The official new BOSH CLI                                  |
-| credhub-cli | The official CredHub CLI                                   |
-| bbl         | The official bosh-bootloader CLI                           |
-| bbr         | The official BOSH Backup and Restore CLI                   |
-| uaa-cli     | The official new UAA CLI (alpha)                           |
+## Install All Packages
+
+To install all packages, run:
+
+```bash
+brew trust cloudfoundry/tap
+brew install --formula cloudfoundry/tap/bbl 
+brew install --formula cloudfoundry/tap/bbr
+brew install --formula cloudfoundry/tap/bosh-cli
+brew install --formula cloudfoundry/tap/cf-cli@8
+brew install --formula cloudfoundry/tap/credhub-cli
+brew install --cask cloudfoundry/tap/uaa-cli
+```
+
+### Troubleshooting Installation
+
+If you encounter trust warnings with Homebrew, you can trust the tap:
+```bash
+brew trust cloudfoundry/tap
+```
+
+## Contributing
 
 Want to change something?
  1. Make a PR
- 1. A Pivotal Tracker story will be created in the Toolsmiths tracker project
- 1. Toolsmiths will move the story to the team who has the most context on the changes, the 'reviewing team'
- 1. The 'reviewing team' will decide the best action to take, including merging/closing/editing the PR
+ 2. The 'reviewing team' will decide the best action to take, including merging/closing/editing the PR

--- a/uaa-cli.rb
+++ b/uaa-cli.rb
@@ -1,11 +1,13 @@
 class UaaCli < Formula
-  desc "CLI for UAA written in golang"
-  homepage "https://github.com/cloudfoundry-incubator/uaa-cli"
-  version "0.10.0"
-  url "https://github.com/cloudfoundry-incubator/uaa-cli/releases/download/0.10.0/uaa-darwin-amd64-0.10.0"
-  sha256 "482cd886a2abd60678c292b126e4c869c1305a610fbe8d05a78207e22edeff88"
+  desc "CLI for UAA written in Go"
+  homepage "https://github.com/cloudfoundry/uaa-cli"
+  version "0.20.1"
+  url "https://github.com/cloudfoundry/uaa-cli/releases/download/v#{version}/uaa-darwin-amd64-#{version}"
+  sha256 "5b2a7a757eec270fcc148268612207f816db253b45ffd4e7098f2409313e5971"
 
   def install
+    opoo "This formula is deprecated. Please use 'brew install --cask cloudfoundry/tap/uaa-cli' instead."
+    opoo "The cask provides newer versions and better installation experience."
     bin.install "uaa-darwin-amd64-#{version}" => "uaa"
   end
 


### PR DESCRIPTION

Improve documentation and add Cask installation instructions

Update UAA CLI formula to 0.20.1 and mark as deprecated Will be released as a Cask, via goreleaser